### PR TITLE
Drop navbar-brand positioning

### DIFF
--- a/default/bootstrap-ehealth.scss
+++ b/default/bootstrap-ehealth.scss
@@ -144,11 +144,6 @@
   text-shadow: 0 0 0;
 }
 
-.navbar-brand {
-  position: relative;
-  top: -6px;
-}
-
 .navbar-brand > img {
   height: 32px;
   display: inline-block;


### PR DESCRIPTION
This is causing the navbar to become unaligned when using a differing base font
size.
